### PR TITLE
feat: CORS middleware with preflight handling and per-route overrides

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -40,7 +40,11 @@ func main() {
 
 	handlers := make(map[string]http.Handler, len(cfg.Routes))
 	for i := range cfg.Routes {
-		handlers[cfg.Routes[i].Name] = proxy.NewProxyHandler(&cfg.Routes[i])
+		h := proxy.NewProxyHandler(&cfg.Routes[i])
+		if cfg.Routes[i].CORS != nil {
+			h = middleware.CORSOverride(*cfg.Routes[i].CORS)(h)
+		}
+		handlers[cfg.Routes[i].Name] = h
 	}
 
 	r := router.New(cfg.Routes, handlers)
@@ -55,6 +59,7 @@ func main() {
 		middleware.RequestID(),
 		middleware.Logging(logger),
 		metrics.Middleware(),
+		middleware.CORS(cfg.CORS),
 	)
 
 	mux := http.NewServeMux()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type CORSConfig struct {
 	AllowedOrigins   []string `yaml:"allowed_origins"`
 	AllowedMethods   []string `yaml:"allowed_methods"`
 	AllowedHeaders   []string `yaml:"allowed_headers"`
+	ExposedHeaders   []string `yaml:"exposed_headers"`
 	AllowCredentials bool     `yaml:"allow_credentials"`
 	MaxAge           int      `yaml:"max_age"`
 }
@@ -102,6 +103,7 @@ type RouteConfig struct {
 	Name           string                `yaml:"name"`
 	Match          MatchConfig           `yaml:"match"`
 	Upstream       UpstreamConfig        `yaml:"upstream"`
+	CORS           *CORSConfig           `yaml:"cors"`
 	Auth           *RouteAuthConfig      `yaml:"auth"`
 	RateLimit      *RouteLimitConfig     `yaml:"rate_limit"`
 	Retry          *RetryConfig          `yaml:"retry"`

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,0 +1,198 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/NextSolutionCUU/api-gateway/internal/config"
+)
+
+// corsOverrideMarker is an internal response header used to signal that a
+// per-route CORS override has been applied. It is removed before the response
+// is sent to the client.
+const corsOverrideMarker = "X-Gateway-Cors-Override"
+
+// CORS returns a middleware that handles CORS preflight requests (returning
+// 204 without forwarding upstream) and injects CORS headers on regular
+// requests using the provided global configuration.
+func CORS(globalCfg config.CORSConfig) Middleware {
+	if isWildcard(globalCfg.AllowedOrigins) && globalCfg.AllowCredentials {
+		slog.Warn("CORS: wildcard origin with allow_credentials is invalid per spec; will use requesting origin instead of *")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if isPreflight(r) {
+				handlePreflight(w, origin, globalCfg)
+				return
+			}
+
+			crw := &corsResponseWriter{
+				ResponseWriter: w,
+				origin:         origin,
+				cfg:            globalCfg,
+				isOverride:     false,
+			}
+			next.ServeHTTP(crw, r)
+		})
+	}
+}
+
+// CORSOverride returns a per-route middleware that completely replaces the
+// global CORS configuration for matching requests. It does not handle
+// preflights (those are handled by the global CORS middleware before routing).
+func CORSOverride(routeCfg config.CORSConfig) Middleware {
+	if isWildcard(routeCfg.AllowedOrigins) && routeCfg.AllowCredentials {
+		slog.Warn("CORS: route override has wildcard origin with allow_credentials; will use requesting origin instead of *")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			crw := &corsResponseWriter{
+				ResponseWriter: w,
+				origin:         origin,
+				cfg:            routeCfg,
+				isOverride:     true,
+			}
+			next.ServeHTTP(crw, r)
+		})
+	}
+}
+
+// corsResponseWriter intercepts WriteHeader to inject CORS headers before
+// the status code is sent to the client.
+type corsResponseWriter struct {
+	http.ResponseWriter
+	origin      string
+	cfg         config.CORSConfig
+	headersSent bool
+	isOverride  bool
+}
+
+func (crw *corsResponseWriter) WriteHeader(code int) {
+	if !crw.headersSent {
+		crw.headersSent = true
+		h := crw.ResponseWriter.Header()
+		if crw.isOverride {
+			// Per-route override: inject headers and set marker so the
+			// outer (global) corsResponseWriter skips its own injection.
+			injectCORSHeaders(crw.ResponseWriter, crw.origin, crw.cfg)
+			h.Set(corsOverrideMarker, "1")
+		} else {
+			if h.Get(corsOverrideMarker) != "" {
+				// Per-route override already applied — clean up marker.
+				h.Del(corsOverrideMarker)
+			} else {
+				injectCORSHeaders(crw.ResponseWriter, crw.origin, crw.cfg)
+			}
+		}
+	}
+	crw.ResponseWriter.WriteHeader(code)
+}
+
+func (crw *corsResponseWriter) Write(b []byte) (int, error) {
+	if !crw.headersSent {
+		crw.WriteHeader(http.StatusOK)
+	}
+	return crw.ResponseWriter.Write(b)
+}
+
+// Flush delegates to the underlying writer if it supports http.Flusher.
+func (crw *corsResponseWriter) Flush() {
+	if f, ok := crw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap returns the underlying ResponseWriter for http.ResponseController.
+func (crw *corsResponseWriter) Unwrap() http.ResponseWriter {
+	return crw.ResponseWriter
+}
+
+func isWildcard(origins []string) bool {
+	for _, o := range origins {
+		if o == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func isOriginAllowed(origin string, allowedOrigins []string) bool {
+	for _, o := range allowedOrigins {
+		if o == "*" || o == origin {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveAllowOrigin(origin string, cfg config.CORSConfig) string {
+	if !isOriginAllowed(origin, cfg.AllowedOrigins) {
+		return ""
+	}
+	if isWildcard(cfg.AllowedOrigins) && !cfg.AllowCredentials {
+		return "*"
+	}
+	return origin
+}
+
+func isPreflight(r *http.Request) bool {
+	return r.Method == http.MethodOptions &&
+		r.Header.Get("Origin") != "" &&
+		r.Header.Get("Access-Control-Request-Method") != ""
+}
+
+func handlePreflight(w http.ResponseWriter, origin string, cfg config.CORSConfig) {
+	h := w.Header()
+	h.Set("Vary", "Origin")
+
+	allowOrigin := resolveAllowOrigin(origin, cfg)
+	if allowOrigin == "" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	h.Set("Access-Control-Allow-Origin", allowOrigin)
+	h.Set("Access-Control-Allow-Methods", strings.Join(cfg.AllowedMethods, ", "))
+	if len(cfg.AllowedHeaders) > 0 {
+		h.Set("Access-Control-Allow-Headers", strings.Join(cfg.AllowedHeaders, ", "))
+	}
+	if cfg.MaxAge > 0 {
+		h.Set("Access-Control-Max-Age", fmt.Sprintf("%d", cfg.MaxAge))
+	}
+	if cfg.AllowCredentials {
+		h.Set("Access-Control-Allow-Credentials", "true")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func injectCORSHeaders(w http.ResponseWriter, origin string, cfg config.CORSConfig) {
+	h := w.Header()
+	h.Set("Vary", "Origin")
+
+	allowOrigin := resolveAllowOrigin(origin, cfg)
+	if allowOrigin == "" {
+		return
+	}
+
+	h.Set("Access-Control-Allow-Origin", allowOrigin)
+	if cfg.AllowCredentials {
+		h.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if len(cfg.ExposedHeaders) > 0 {
+		h.Set("Access-Control-Expose-Headers", strings.Join(cfg.ExposedHeaders, ", "))
+	}
+}

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -1,0 +1,360 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NextSolutionCUU/api-gateway/internal/config"
+)
+
+func corsConfig(origins []string) config.CORSConfig {
+	return config.CORSConfig{
+		AllowedOrigins: origins,
+		AllowedMethods: []string{"GET", "POST", "PUT"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+		MaxAge:         3600,
+	}
+}
+
+func TestPreflight_AllowedOrigin_Returns204(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	nextCalled := false
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	r := httptest.NewRequest("OPTIONS", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	r.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Errorf("expected origin header, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Access-Control-Allow-Methods") != "GET, POST, PUT" {
+		t.Errorf("expected methods header, got %q", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+	if nextCalled {
+		t.Error("next handler should not be called for preflight")
+	}
+}
+
+func TestPreflight_MaxAge(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	cfg.MaxAge = 7200
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	r := httptest.NewRequest("OPTIONS", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Max-Age") != "7200" {
+		t.Errorf("expected max-age 7200, got %q", w.Header().Get("Access-Control-Max-Age"))
+	}
+}
+
+func TestPreflight_Credentials(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	cfg.AllowCredentials = true
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	r := httptest.NewRequest("OPTIONS", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Credentials") != "true" {
+		t.Errorf("expected credentials header, got %q", w.Header().Get("Access-Control-Allow-Credentials"))
+	}
+}
+
+func TestRegularRequest_AllowedOrigin(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Errorf("expected origin header, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestRegularRequest_DisallowedOrigin(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://evil.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no ACAO header, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Vary") != "Origin" {
+		t.Errorf("expected Vary: Origin, got %q", w.Header().Get("Vary"))
+	}
+}
+
+func TestPreflight_DisallowedOrigin(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	r := httptest.NewRequest("OPTIONS", "/test", nil)
+	r.Header.Set("Origin", "https://evil.com")
+	r.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no ACAO header, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Vary") != "Origin" {
+		t.Errorf("expected Vary: Origin, got %q", w.Header().Get("Vary"))
+	}
+}
+
+func TestWildcardOrigin(t *testing.T) {
+	cfg := corsConfig([]string{"*"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://any-origin.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected *, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestWildcardOrigin_WithCredentials(t *testing.T) {
+	cfg := corsConfig([]string{"*"})
+	cfg.AllowCredentials = true
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	// Should use requesting origin instead of * when credentials are enabled
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Errorf("expected requesting origin, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Access-Control-Allow-Credentials") != "true" {
+		t.Errorf("expected credentials header")
+	}
+}
+
+func TestNoOriginHeader(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	nextCalled := false
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	// No Origin header
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if !nextCalled {
+		t.Error("next handler should be called")
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no CORS headers, got ACAO=%q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Vary") != "" {
+		t.Errorf("expected no Vary header, got %q", w.Header().Get("Vary"))
+	}
+}
+
+func TestVaryOrigin_AlwaysSet(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Allowed origin
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	if w.Header().Get("Vary") != "Origin" {
+		t.Errorf("expected Vary: Origin for allowed origin, got %q", w.Header().Get("Vary"))
+	}
+
+	// Disallowed origin
+	r = httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://evil.com")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	if w.Header().Get("Vary") != "Origin" {
+		t.Errorf("expected Vary: Origin for disallowed origin, got %q", w.Header().Get("Vary"))
+	}
+}
+
+func TestMultipleAllowedOrigins(t *testing.T) {
+	cfg := corsConfig([]string{"https://a.com", "https://b.com", "https://c.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://b.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://b.com" {
+		t.Errorf("expected https://b.com, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestPerRouteCORSOverride(t *testing.T) {
+	globalCfg := corsConfig([]string{"https://global.com"})
+	routeCfg := config.CORSConfig{
+		AllowedOrigins: []string{"https://route.com"},
+		AllowedMethods: []string{"GET"},
+		AllowedHeaders: []string{"X-Custom"},
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CORS(globalCfg)(CORSOverride(routeCfg)(inner))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://route.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://route.com" {
+		t.Errorf("expected route origin, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	// Marker should be cleaned up
+	if w.Header().Get(corsOverrideMarker) != "" {
+		t.Error("internal marker header should not leak to response")
+	}
+}
+
+func TestPerRouteCORSOverride_CompleteReplacement(t *testing.T) {
+	globalCfg := corsConfig([]string{"https://global.com"})
+	globalCfg.AllowCredentials = true
+	routeCfg := config.CORSConfig{
+		AllowedOrigins: []string{"https://route.com"},
+		AllowedMethods: []string{"GET"},
+		// No AllowCredentials — should NOT inherit from global
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CORS(globalCfg)(CORSOverride(routeCfg)(inner))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://route.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Header().Get("Access-Control-Allow-Credentials") != "" {
+		t.Errorf("expected no credentials header (complete replacement), got %q",
+			w.Header().Get("Access-Control-Allow-Credentials"))
+	}
+	// Global config should NOT have been applied
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://route.com" {
+		t.Errorf("expected route origin, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestPreflight_NotActualPreflight(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	nextCalled := false
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// OPTIONS with Origin but without Access-Control-Request-Method
+	r := httptest.NewRequest("OPTIONS", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if !nextCalled {
+		t.Error("next handler should be called for non-preflight OPTIONS")
+	}
+}
+
+func TestResponseWriterFlusher(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	flushed := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+	handler := CORS(cfg)(inner)
+
+	fw := &flushTracker{ResponseWriter: httptest.NewRecorder(), flushed: &flushed}
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	handler.ServeHTTP(fw, r)
+
+	if !flushed {
+		t.Error("Flush should delegate to underlying writer")
+	}
+}
+
+type flushTracker struct {
+	http.ResponseWriter
+	flushed *bool
+}
+
+func (f *flushTracker) Flush() {
+	*f.flushed = true
+}
+
+func TestCORSHeaders_NotDuplicated(t *testing.T) {
+	cfg := corsConfig([]string{"https://example.com"})
+	handler := CORS(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	// Headers should be set with Set(), not Add(), so no duplicates
+	origins := w.Header().Values("Access-Control-Allow-Origin")
+	if len(origins) != 1 {
+		t.Errorf("expected 1 ACAO value, got %d: %v", len(origins), origins)
+	}
+}

--- a/progress.txt
+++ b/progress.txt
@@ -54,3 +54,24 @@
   - cmd/gateway/main.go (wired logging, metrics middleware, /health, /metrics endpoints)
   - go.mod, go.sum (prometheus dependency)
 - All validations pass: gofmt, go test ./..., go vet ./...
+
+## Phase 3: CORS — COMPLETE
+
+- Task: CORS preflight handling, response header injection, per-route override
+- Key decisions:
+  - No external deps; stdlib only
+  - corsResponseWriter intercepts WriteHeader to inject CORS headers at write time (after proxy copies upstream headers)
+  - Per-route override uses isOverride flag + internal marker header (X-Gateway-Cors-Override) to prevent global CORS from overwriting; marker deleted before response sent
+  - Complete replacement semantics: per-route CORS fully replaces global, no field-level merge
+  - Wildcard + credentials edge case: logs warning at construction, uses requesting origin instead of *
+  - Preflight = OPTIONS + Origin + Access-Control-Request-Method (all three required); plain OPTIONS forwarded to handler
+  - CORS positioned last in global chain (after Metrics, before Router)
+  - Preflights use global config only (router hasn't matched yet); per-route overrides apply to regular requests via per-route handler chain
+  - Added ExposedHeaders field to CORSConfig, CORS pointer to RouteConfig
+- Files created:
+  - internal/middleware/cors.go (CORS, CORSOverride, corsResponseWriter, helpers)
+  - internal/middleware/cors_test.go (16 tests)
+- Files modified:
+  - internal/config/config.go (added ExposedHeaders to CORSConfig, CORS *CORSConfig to RouteConfig)
+  - cmd/gateway/main.go (CORS in global chain, CORSOverride wired per-route)
+- All validations pass: gofmt, go test ./... -race, go vet ./...

--- a/tasks.json
+++ b/tasks.json
@@ -18,7 +18,7 @@
     "number": 3,
     "plan": "plans/phase3-cors.md",
     "depends_on": [1],
-    "status": "open"
+    "status": "complete"
   },
   {
     "title": "Phase 4: Authentication",


### PR DESCRIPTION
## Summary

- **Global CORS middleware** handles OPTIONS preflight requests (returns 204 without forwarding upstream) and injects `Access-Control-*` response headers on regular requests
- **Per-route `CORSOverride`** completely replaces global CORS config for specific routes using an internal marker header pattern — no field-level merging, full replacement semantics
- Added `ExposedHeaders` field to `CORSConfig` and `CORS *CORSConfig` pointer to `RouteConfig` for per-route overrides
- Wildcard origins (`*`) with `allow_credentials: true` logs a warning and echoes the requesting origin instead of `*` (per CORS spec)
- 16 tests covering preflights, allowed/disallowed origins, wildcard, credentials, per-route override, Vary header, Flusher delegation, and no-duplication guarantees
- All tests pass with `-race` flag, no data races

## Test plan

- [x] `go test ./... -race` — all 16 CORS tests pass, no race conditions
- [x] `go vet ./...` — no issues
- [x] `gofmt -s -w .` — properly formatted
- [ ] Verify preflight OPTIONS returns 204 with correct headers
- [ ] Verify per-route CORS override replaces (not merges) global config
- [ ] Verify wildcard + credentials edge case uses requesting origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)