### PR TITLE
feat: support hot reload of configuration via SIGHUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ cors:
 
 Handles `SIGINT` and `SIGTERM`. Stops accepting new connections, drains in-flight requests within a configurable timeout (default 15s), and cleans up resources (Redis connections, OIDC background goroutines, rate limiter cleanup).
 
+### Hot Reload
+
+Reload configuration via `SIGHUP` without restarting the gateway. Routes, rate limits, CORS, transforms, circuit breaker thresholds, retry settings, and auth provider assignments are reloaded atomically. In-flight requests complete with the old configuration while new requests use the updated one.
+
+```bash
+# Edit config, then:
+kill -HUP $(pgrep gateway)
+```
+
+Non-reloadable fields (server host/port, rate limit backend, auth provider definitions) are detected and logged as warnings. Invalid configurations are rejected — the old config continues serving. See [docs/hot-reload.md](docs/hot-reload.md) for details.
+
 ### Panic Recovery
 
 Global recovery middleware catches panics in the handler chain, logs the stack trace, and returns a `500 Internal Server Error` instead of crashing the process.
@@ -487,7 +498,7 @@ make clean       # Remove build artifacts
 - [ ] **OpenTelemetry tracing** — Distributed tracing with W3C `traceparent` propagation and OTLP export ([#17](https://github.com/jesus-mata/tanugate/issues/17))
 - [ ] **Forward auth claims to upstreams** — Inject authenticated identity (sub, email, roles) as headers to upstream services ([#18](https://github.com/jesus-mata/tanugate/issues/18))
 - [ ] **Config validation CLI** — `gateway validate` subcommand for pre-deployment config checks ([#19](https://github.com/jesus-mata/tanugate/issues/19))
-- [ ] **Hot reload** — Reload configuration via `SIGHUP` without restarting the gateway ([#20](https://github.com/jesus-mata/tanugate/issues/20))
+- [x] **Hot reload** — Reload configuration via `SIGHUP` without restarting the gateway ([#20](https://github.com/jesus-mata/tanugate/issues/20))
 - [ ] **Request body size limits** — Per-route and global max request body enforcement ([#21](https://github.com/jesus-mata/tanugate/issues/21))
 - [ ] **Helm chart** — Packaged Kubernetes deployment
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -5,9 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/jesus-mata/tanugate/internal/config"
@@ -24,6 +26,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// handlerRef wraps an http.Handler for use with atomic.Pointer.
+type handlerRef struct{ h http.Handler }
 
 func main() {
 	configPath := flag.String("config", "config/gateway.yaml", "path to configuration file")
@@ -87,61 +92,21 @@ func main() {
 	registry.MustRegister(collectors.NewGoCollector())
 	metrics := observability.NewMetricsCollector(registry)
 
-	handlers := make(map[string]http.Handler, len(cfg.Routes))
-	for i := range cfg.Routes {
-		h := proxy.NewProxyHandler(&cfg.Routes[i])
-
-		// Wrap with circuit breaker and/or retry.
-		route := &cfg.Routes[i]
-		if route.CircuitBreaker != nil {
-			cb := circuitbreaker.New(route.CircuitBreaker, route.Name,
-				circuitbreaker.WithOnStateChange(func(routeName string, from, to circuitbreaker.State) {
-					slog.Info("circuit breaker state change", "route", routeName, "from", from, "to", to)
-					metrics.CircuitBreakerState.WithLabelValues(routeName, to.String()).Set(1)
-					metrics.CircuitBreakerState.WithLabelValues(routeName, from.String()).Set(0)
-				}),
-			)
-			if route.Retry != nil {
-				h = retry.Retry(route.Retry, cb, h)
-			} else {
-				h = retry.WithCircuitBreaker(cb, h)
-			}
-		} else if route.Retry != nil {
-			h = retry.Retry(route.Retry, nil, h)
-		}
-
-		// Wrap with request/response transforms.
-		if route.Transform != nil {
-			h = transform.RequestTransform(route.Transform.Request, route.Transform.MaxBodySize)(
-				transform.ResponseTransform(route.Transform.Response, route.Transform.MaxBodySize)(h))
-		}
-
-		if cfg.Routes[i].CORS != nil {
-			h = middleware.CORSOverride(*cfg.Routes[i].CORS)(h)
-		}
-
-		// Auth and rate-limit are per-route: the router sets route context
-		// before dispatching, so these middleware can read the matched route.
-		h = auth.Middleware(logger, authenticators)(h)
-		h = ratelimit.RateLimit(limiter, metrics, trustedProxies)(h)
-
-		handlers[cfg.Routes[i].Name] = h
+	handler, err := buildHandler(cfg, limiter, authenticators, metrics, trustedProxies, logger)
+	if err != nil {
+		slog.Error("failed to build handler", "error", err)
+		os.Exit(1)
 	}
 
-	r := router.New(cfg.Routes, handlers)
-
-	globalChain := middleware.Chain(
-		middleware.Recovery(),
-		middleware.RequestID(),
-		middleware.Logging(logger),
-		metrics.Middleware(),
-		middleware.CORS(cfg.CORS),
-	)
+	var current atomic.Pointer[handlerRef]
+	current.Store(&handlerRef{h: handler})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", observability.HealthHandler(cfg, healthChecker))
 	mux.Handle("GET /metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-	mux.Handle("/", globalChain(r))
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().h.ServeHTTP(w, r)
+	}))
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
@@ -151,8 +116,8 @@ func main() {
 		IdleTimeout:  cfg.Server.IdleTimeout,
 	}
 
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -161,7 +126,16 @@ func main() {
 		}
 	}()
 
-	<-quit
+loop:
+	for sig := range sigCh {
+		switch sig {
+		case syscall.SIGHUP:
+			handleReload(*configPath, cfg, &current, limiter, authenticators, metrics, trustedProxies, logger)
+		default:
+			break loop
+		}
+	}
+
 	slog.Info("Shutting down server...")
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), cfg.Server.ShutdownTimeout)
@@ -189,6 +163,121 @@ func main() {
 	}
 
 	slog.Info("Server stopped")
+}
+
+// buildHandler creates the full handler pipeline from the given configuration
+// and shared resources. It returns an error if handler construction fails
+// (e.g., from invalid regex patterns).
+func buildHandler(
+	cfg *config.GatewayConfig,
+	limiter ratelimit.Limiter,
+	authenticators map[string]auth.Authenticator,
+	metrics *observability.MetricsCollector,
+	trustedProxies []*net.IPNet,
+	logger *slog.Logger,
+) (h http.Handler, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic building handler: %v", r)
+		}
+	}()
+
+	handlers := make(map[string]http.Handler, len(cfg.Routes))
+	for i := range cfg.Routes {
+		rh := proxy.NewProxyHandler(&cfg.Routes[i])
+
+		route := &cfg.Routes[i]
+		if route.CircuitBreaker != nil {
+			cb := circuitbreaker.New(route.CircuitBreaker, route.Name,
+				circuitbreaker.WithOnStateChange(func(routeName string, from, to circuitbreaker.State) {
+					slog.Info("circuit breaker state change", "route", routeName, "from", from, "to", to)
+					metrics.CircuitBreakerState.WithLabelValues(routeName, to.String()).Set(1)
+					metrics.CircuitBreakerState.WithLabelValues(routeName, from.String()).Set(0)
+				}),
+			)
+			if route.Retry != nil {
+				rh = retry.Retry(route.Retry, cb, rh)
+			} else {
+				rh = retry.WithCircuitBreaker(cb, rh)
+			}
+		} else if route.Retry != nil {
+			rh = retry.Retry(route.Retry, nil, rh)
+		}
+
+		if route.Transform != nil {
+			rh = transform.RequestTransform(route.Transform.Request, route.Transform.MaxBodySize)(
+				transform.ResponseTransform(route.Transform.Response, route.Transform.MaxBodySize)(rh))
+		}
+
+		if cfg.Routes[i].CORS != nil {
+			rh = middleware.CORSOverride(*cfg.Routes[i].CORS)(rh)
+		}
+
+		rh = auth.Middleware(logger, authenticators)(rh)
+		rh = ratelimit.RateLimit(limiter, metrics, trustedProxies)(rh)
+
+		handlers[cfg.Routes[i].Name] = rh
+	}
+
+	r := router.New(cfg.Routes, handlers)
+
+	globalChain := middleware.Chain(
+		middleware.Recovery(),
+		middleware.RequestID(),
+		middleware.Logging(logger),
+		metrics.Middleware(),
+		middleware.CORS(cfg.CORS),
+	)
+
+	return globalChain(r), nil
+}
+
+// handleReload loads the configuration from disk, validates it, builds a new
+// handler pipeline, and atomically swaps it in. If any step fails, the old
+// handler continues serving and an error is logged.
+func handleReload(
+	configPath string,
+	currentCfg *config.GatewayConfig,
+	current *atomic.Pointer[handlerRef],
+	limiter ratelimit.Limiter,
+	authenticators map[string]auth.Authenticator,
+	metrics *observability.MetricsCollector,
+	trustedProxies []*net.IPNet,
+	logger *slog.Logger,
+) {
+	slog.Info("Received SIGHUP, reloading configuration...", "path", configPath)
+
+	newCfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		slog.Error("config reload failed: invalid configuration, keeping current config", "error", err)
+		return
+	}
+
+	// Warn about non-reloadable changes.
+	for _, w := range config.NonReloadableChanges(currentCfg, newCfg) {
+		slog.Warn("non-reloadable change detected (ignored)", "detail", w)
+	}
+
+	newHandler, err := buildHandler(newCfg, limiter, authenticators, metrics, trustedProxies, logger)
+	if err != nil {
+		slog.Error("config reload failed: could not build handler, keeping current config", "error", err)
+		return
+	}
+
+	current.Store(&handlerRef{h: newHandler})
+
+	// Log what changed.
+	changes := config.DiffSummary(currentCfg, newCfg)
+	if len(changes) == 0 {
+		slog.Info("Configuration reloaded (no reloadable changes detected)")
+	} else {
+		slog.Info("Configuration reloaded successfully", "changes", changes)
+	}
+
+	// Update the current config reference for future reloads.
+	// Copy the reloadable fields into the current config.
+	currentCfg.Routes = newCfg.Routes
+	currentCfg.CORS = newCfg.CORS
 }
 
 func parseLogLevel(level string) slog.Level {

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -1,0 +1,117 @@
+# Hot Reload
+
+Tanugate supports zero-downtime configuration reload via the `SIGHUP` signal. When SIGHUP is received, the gateway re-reads the configuration file, validates it, builds a new handler pipeline, and atomically swaps it in — all without dropping existing connections.
+
+## Reloadable vs Non-Reloadable
+
+| Reloadable (applied on SIGHUP) | Non-reloadable (logged as warning, ignored) |
+|---|---|
+| Routes (add/remove/modify) | Server host/port/timeouts |
+| Rate limit settings (per-route) | Rate limit backend type |
+| CORS configuration (global + per-route) | Redis connection settings |
+| Transform rules | Auth provider definitions |
+| Circuit breaker thresholds | Logging level |
+| Retry settings | |
+| Auth provider assignment to routes | |
+
+When non-reloadable fields change, a warning is logged for each one and only reloadable parts are applied.
+
+## How to Trigger a Reload
+
+### Direct signal
+
+```bash
+kill -HUP $(pgrep gateway)
+```
+
+### Docker
+
+```bash
+docker kill --signal=HUP <container_id>
+```
+
+### Docker Compose / Swarm
+
+```bash
+docker compose kill -s HUP gateway
+```
+
+### Kubernetes
+
+```bash
+kubectl exec <pod-name> -- kill -HUP 1
+```
+
+## Reload Behavior
+
+1. **Load** — The configuration file is re-read from disk (same path as the original `-config` flag).
+2. **Validate** — Full validation runs including regex compilation, auth provider references, etc.
+3. **Check non-reloadable changes** — Each non-reloadable field that differs is logged as a warning.
+4. **Build** — A new handler pipeline (per-route handlers + router + global middleware chain) is constructed.
+5. **Swap** — The new handler is atomically swapped in via `sync/atomic.Pointer`.
+6. **Log** — A summary of what changed (routes added/removed/modified, CORS changes) is logged.
+
+### What Happens on Invalid Config
+
+If the new configuration fails validation (bad YAML, invalid regex, missing auth provider references), the reload is aborted entirely. The old handler continues serving all requests, and an error is logged:
+
+```
+ERROR config reload failed: invalid configuration, keeping current config
+```
+
+### What Happens on Build Failure
+
+If handler construction panics (e.g., from unexpected runtime errors), the panic is recovered, an error is logged, and the old handler continues serving.
+
+## In-Flight Request Safety
+
+The atomic swap pattern ensures:
+
+- **In-flight requests** complete with the old handler (they hold a reference to it).
+- **New requests** after the swap use the new handler.
+- **No locking** on the hot path — just one atomic pointer load per request.
+
+## Rate Limit State Preservation
+
+The rate limiter instance is **reused across reloads**. Token bucket state (or Redis state) persists:
+
+- Existing rate limit counters survive a reload.
+- If a route is removed, stale buckets are cleaned up by the memory limiter's background goroutine (evicts idle entries after ~5 minutes).
+- If a route's rate limit settings change (e.g., `requests_per_window` increases), new requests use the new limits while existing bucket state naturally expires.
+
+## Circuit Breaker State
+
+Circuit breakers are **recreated on reload** (state resets). This is intentional — upstream configuration may have changed, and fresh state matches the new thresholds.
+
+## Example Workflow
+
+1. Start the gateway:
+
+```bash
+./bin/gateway -config config/gateway.yaml
+```
+
+2. Edit the config to change a route's rate limit:
+
+```yaml
+routes:
+  - name: "api"
+    rate_limit:
+      requests_per_window: 200  # was 100
+      window: 1m
+```
+
+3. Send SIGHUP:
+
+```bash
+kill -HUP $(pgrep gateway)
+```
+
+4. Check the logs:
+
+```
+INFO Received SIGHUP, reloading configuration... path=config/gateway.yaml
+INFO Configuration reloaded successfully changes=["route \"api\": modified"]
+```
+
+5. Verify the new rate limit is in effect by checking `X-RateLimit-Limit` response headers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,6 +261,13 @@ func (cfg *GatewayConfig) Validate() error {
 	var errs []string
 
 	for _, route := range cfg.Routes {
+		// Validate path regex compiles.
+		if route.Match.PathRegex != "" {
+			if _, err := regexp.Compile(route.Match.PathRegex); err != nil {
+				errs = append(errs, fmt.Sprintf("route %q: invalid path_regex %q: %v", route.Name, route.Match.PathRegex, err))
+			}
+		}
+
 		if route.Auth == nil {
 			continue
 		}
@@ -298,4 +305,408 @@ func (cfg *GatewayConfig) Validate() error {
 		return fmt.Errorf("config validation failed: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// NonReloadableChanges compares old and new configurations and returns a list
+// of human-readable warnings for non-reloadable fields that differ. These
+// fields require a full restart to take effect.
+func NonReloadableChanges(old, new *GatewayConfig) []string {
+	var warnings []string
+
+	if old.Server.Host != new.Server.Host {
+		warnings = append(warnings, fmt.Sprintf("server.host changed (%q -> %q) — requires restart", old.Server.Host, new.Server.Host))
+	}
+	if old.Server.Port != new.Server.Port {
+		warnings = append(warnings, fmt.Sprintf("server.port changed (%d -> %d) — requires restart", old.Server.Port, new.Server.Port))
+	}
+	if old.Server.ReadTimeout != new.Server.ReadTimeout {
+		warnings = append(warnings, fmt.Sprintf("server.read_timeout changed (%v -> %v) — requires restart", old.Server.ReadTimeout, new.Server.ReadTimeout))
+	}
+	if old.Server.WriteTimeout != new.Server.WriteTimeout {
+		warnings = append(warnings, fmt.Sprintf("server.write_timeout changed (%v -> %v) — requires restart", old.Server.WriteTimeout, new.Server.WriteTimeout))
+	}
+	if old.Server.IdleTimeout != new.Server.IdleTimeout {
+		warnings = append(warnings, fmt.Sprintf("server.idle_timeout changed (%v -> %v) — requires restart", old.Server.IdleTimeout, new.Server.IdleTimeout))
+	}
+	if old.Server.ShutdownTimeout != new.Server.ShutdownTimeout {
+		warnings = append(warnings, fmt.Sprintf("server.shutdown_timeout changed (%v -> %v) — requires restart", old.Server.ShutdownTimeout, new.Server.ShutdownTimeout))
+	}
+	if !stringSliceEqual(old.Server.TrustedProxies, new.Server.TrustedProxies) {
+		warnings = append(warnings, "server.trusted_proxies changed — requires restart")
+	}
+
+	if old.RateLimit.Backend != new.RateLimit.Backend {
+		warnings = append(warnings, fmt.Sprintf("rate_limit.backend changed (%q -> %q) — requires restart", old.RateLimit.Backend, new.RateLimit.Backend))
+	}
+	if !redisConfigEqual(old.RateLimit.Redis, new.RateLimit.Redis) {
+		warnings = append(warnings, "rate_limit.redis settings changed — requires restart")
+	}
+
+	if !authProvidersEqual(old.AuthProviders, new.AuthProviders) {
+		warnings = append(warnings, "auth_providers definitions changed — requires restart")
+	}
+
+	if old.Logging.Level != new.Logging.Level {
+		warnings = append(warnings, fmt.Sprintf("logging.level changed (%q -> %q) — requires restart", old.Logging.Level, new.Logging.Level))
+	}
+
+	return warnings
+}
+
+func redisConfigEqual(a, b *RedisConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Addr == b.Addr && a.Password == b.Password && a.DB == b.DB
+}
+
+func authProvidersEqual(a, b map[string]AuthProvider) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, ap := range a {
+		bp, ok := b[name]
+		if !ok {
+			return false
+		}
+		if ap.Type != bp.Type {
+			return false
+		}
+		// Compare sub-configs by presence (definition changes need restart).
+		if !jwtConfigEqual(ap.JWT, bp.JWT) {
+			return false
+		}
+		if !apiKeyConfigEqual(ap.APIKey, bp.APIKey) {
+			return false
+		}
+		if !oidcConfigEqual(ap.OIDC, bp.OIDC) {
+			return false
+		}
+	}
+	return true
+}
+
+func jwtConfigEqual(a, b *JWTConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Secret == b.Secret && a.PublicKeyFile == b.PublicKeyFile &&
+		a.Algorithm == b.Algorithm && a.Issuer == b.Issuer && a.Audience == b.Audience
+}
+
+func apiKeyConfigEqual(a, b *APIKeyConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Header != b.Header {
+		return false
+	}
+	if len(a.Keys) != len(b.Keys) {
+		return false
+	}
+	for i := range a.Keys {
+		if a.Keys[i].Key != b.Keys[i].Key || a.Keys[i].Name != b.Keys[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func oidcConfigEqual(a, b *OIDCConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.IssuerURL != b.IssuerURL || a.JWKSURL != b.JWKSURL ||
+		a.IntrospectionURL != b.IntrospectionURL ||
+		a.ClientID != b.ClientID || a.ClientSecret != b.ClientSecret ||
+		a.Audience != b.Audience || a.SkipIssuerCheck != b.SkipIssuerCheck {
+		return false
+	}
+	if len(a.AllowedAlgorithms) != len(b.AllowedAlgorithms) {
+		return false
+	}
+	for i := range a.AllowedAlgorithms {
+		if a.AllowedAlgorithms[i] != b.AllowedAlgorithms[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// DiffSummary returns a human-readable list of reloadable changes between
+// old and new configurations, suitable for logging after a successful reload.
+func DiffSummary(old, new *GatewayConfig) []string {
+	var changes []string
+
+	// Index old routes by name.
+	oldRoutes := make(map[string]*RouteConfig, len(old.Routes))
+	for i := range old.Routes {
+		oldRoutes[old.Routes[i].Name] = &old.Routes[i]
+	}
+
+	// Detect added and modified routes.
+	newRoutes := make(map[string]*RouteConfig, len(new.Routes))
+	for i := range new.Routes {
+		nr := &new.Routes[i]
+		newRoutes[nr.Name] = nr
+
+		or, existed := oldRoutes[nr.Name]
+		if !existed {
+			changes = append(changes, fmt.Sprintf("route %q: added", nr.Name))
+			continue
+		}
+		if routeChanged(or, nr) {
+			changes = append(changes, fmt.Sprintf("route %q: modified", nr.Name))
+		}
+	}
+
+	// Detect removed routes.
+	for _, or := range old.Routes {
+		if _, exists := newRoutes[or.Name]; !exists {
+			changes = append(changes, fmt.Sprintf("route %q: removed", or.Name))
+		}
+	}
+
+	// Route order changes (affects first-match semantics).
+	if len(old.Routes) == len(new.Routes) && len(changes) == 0 {
+		for i := range old.Routes {
+			if old.Routes[i].Name != new.Routes[i].Name {
+				changes = append(changes, "route evaluation order changed")
+				break
+			}
+		}
+	}
+
+	// CORS changes.
+	if corsChanged(&old.CORS, &new.CORS) {
+		changes = append(changes, "global CORS configuration changed")
+	}
+
+	return changes
+}
+
+func routeChanged(a, b *RouteConfig) bool {
+	if a.Match.PathRegex != b.Match.PathRegex {
+		return true
+	}
+	if !stringSliceEqual(a.Match.Methods, b.Match.Methods) {
+		return true
+	}
+	if a.Upstream.URL != b.Upstream.URL || a.Upstream.PathRewrite != b.Upstream.PathRewrite || a.Upstream.Timeout != b.Upstream.Timeout {
+		return true
+	}
+	if !routeAuthEqual(a.Auth, b.Auth) {
+		return true
+	}
+	if !routeLimitEqual(a.RateLimit, b.RateLimit) {
+		return true
+	}
+	// Consider any change in optional config blocks as a modification.
+	if !retryEqual(a.Retry, b.Retry) {
+		return true
+	}
+	if !cbEqual(a.CircuitBreaker, b.CircuitBreaker) {
+		return true
+	}
+	if corsChanged(a.CORS, b.CORS) {
+		return true
+	}
+	if transformChanged(a.Transform, b.Transform) {
+		return true
+	}
+	return false
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func routeAuthEqual(a, b *RouteAuthConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return stringSliceEqual(a.Providers, b.Providers)
+}
+
+func routeLimitEqual(a, b *RouteLimitConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.RequestsPerWindow == b.RequestsPerWindow && a.Window == b.Window && a.KeySource == b.KeySource
+}
+
+func retryEqual(a, b *RetryConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.MaxRetries != b.MaxRetries || a.InitialDelay != b.InitialDelay || a.Multiplier != b.Multiplier {
+		return false
+	}
+	if len(a.RetryableStatusCodes) != len(b.RetryableStatusCodes) {
+		return false
+	}
+	for i := range a.RetryableStatusCodes {
+		if a.RetryableStatusCodes[i] != b.RetryableStatusCodes[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cbEqual(a, b *CircuitBreakerConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.FailureThreshold == b.FailureThreshold && a.SuccessThreshold == b.SuccessThreshold && a.Timeout == b.Timeout
+}
+
+func transformChanged(a, b *TransformConfig) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	if a.MaxBodySize != b.MaxBodySize {
+		return true
+	}
+	if directionTransformChanged(a.Request, b.Request) {
+		return true
+	}
+	if directionTransformChanged(a.Response, b.Response) {
+		return true
+	}
+	return false
+}
+
+func directionTransformChanged(a, b *DirectionTransform) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	if headerTransformChanged(a.Headers, b.Headers) {
+		return true
+	}
+	if bodyTransformChanged(a.Body, b.Body) {
+		return true
+	}
+	return false
+}
+
+func headerTransformChanged(a, b *HeaderTransform) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	if len(a.Add) != len(b.Add) {
+		return true
+	}
+	for k, v := range a.Add {
+		if b.Add[k] != v {
+			return true
+		}
+	}
+	if !stringSliceEqual(a.Remove, b.Remove) {
+		return true
+	}
+	if len(a.Rename) != len(b.Rename) {
+		return true
+	}
+	for k, v := range a.Rename {
+		if b.Rename[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
+func bodyTransformChanged(a, b *BodyTransform) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	if len(a.InjectFields) != len(b.InjectFields) {
+		return true
+	}
+	for k, v := range a.InjectFields {
+		bv, ok := b.InjectFields[k]
+		if !ok || fmt.Sprintf("%v", v) != fmt.Sprintf("%v", bv) {
+			return true
+		}
+	}
+	if !stringSliceEqual(a.StripFields, b.StripFields) {
+		return true
+	}
+	if len(a.RenameKeys) != len(b.RenameKeys) {
+		return true
+	}
+	for k, v := range a.RenameKeys {
+		if b.RenameKeys[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
+func corsChanged(a, b *CORSConfig) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	if !stringSliceEqual(a.AllowedOrigins, b.AllowedOrigins) {
+		return true
+	}
+	if !stringSliceEqual(a.AllowedMethods, b.AllowedMethods) {
+		return true
+	}
+	if !stringSliceEqual(a.AllowedHeaders, b.AllowedHeaders) {
+		return true
+	}
+	if !stringSliceEqual(a.ExposedHeaders, b.ExposedHeaders) {
+		return true
+	}
+	if a.AllowCredentials != b.AllowCredentials || a.MaxAge != b.MaxAge {
+		return true
+	}
+	return false
 }

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -1,0 +1,427 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidate_InvalidPathRegex(t *testing.T) {
+	yaml := `
+routes:
+  - name: "bad-regex"
+    match:
+      path_regex: "^/api/[invalid"
+    upstream:
+      url: "http://localhost:8080"
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := LoadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for invalid regex, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid path_regex") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNonReloadableChanges_ServerChanges(t *testing.T) {
+	old := &GatewayConfig{
+		Server: ServerConfig{Host: "0.0.0.0", Port: 8080, ReadTimeout: 30 * time.Second},
+	}
+	new := &GatewayConfig{
+		Server: ServerConfig{Host: "127.0.0.1", Port: 9090, ReadTimeout: 60 * time.Second},
+	}
+
+	warnings := NonReloadableChanges(old, new)
+	if len(warnings) < 3 {
+		t.Fatalf("expected at least 3 warnings, got %d: %v", len(warnings), warnings)
+	}
+
+	found := map[string]bool{"host": false, "port": false, "read_timeout": false}
+	for _, w := range warnings {
+		for key := range found {
+			if strings.Contains(w, "server."+key) {
+				found[key] = true
+			}
+		}
+	}
+	for key, ok := range found {
+		if !ok {
+			t.Errorf("expected warning for server.%s", key)
+		}
+	}
+}
+
+func TestNonReloadableChanges_BackendChange(t *testing.T) {
+	old := &GatewayConfig{
+		RateLimit: RateLimitGlobalConfig{Backend: "memory"},
+	}
+	new := &GatewayConfig{
+		RateLimit: RateLimitGlobalConfig{Backend: "redis"},
+	}
+
+	warnings := NonReloadableChanges(old, new)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "rate_limit.backend") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for rate_limit.backend change, got %v", warnings)
+	}
+}
+
+func TestNonReloadableChanges_RedisChange(t *testing.T) {
+	old := &GatewayConfig{
+		RateLimit: RateLimitGlobalConfig{
+			Backend: "redis",
+			Redis:   &RedisConfig{Addr: "localhost:6379"},
+		},
+	}
+	new := &GatewayConfig{
+		RateLimit: RateLimitGlobalConfig{
+			Backend: "redis",
+			Redis:   &RedisConfig{Addr: "redis:6379"},
+		},
+	}
+
+	warnings := NonReloadableChanges(old, new)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "rate_limit.redis") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for rate_limit.redis change, got %v", warnings)
+	}
+}
+
+func TestNonReloadableChanges_AuthProviderChange(t *testing.T) {
+	old := &GatewayConfig{
+		AuthProviders: map[string]AuthProvider{
+			"jwt_default": {Type: "jwt", JWT: &JWTConfig{Secret: "old-secret", Algorithm: "HS256"}},
+		},
+	}
+	new := &GatewayConfig{
+		AuthProviders: map[string]AuthProvider{
+			"jwt_default": {Type: "jwt", JWT: &JWTConfig{Secret: "new-secret", Algorithm: "HS256"}},
+		},
+	}
+
+	warnings := NonReloadableChanges(old, new)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "auth_providers") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for auth_providers change, got %v", warnings)
+	}
+}
+
+func TestNonReloadableChanges_LoggingLevelChange(t *testing.T) {
+	old := &GatewayConfig{Logging: LoggingConfig{Level: "info"}}
+	new := &GatewayConfig{Logging: LoggingConfig{Level: "debug"}}
+
+	warnings := NonReloadableChanges(old, new)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "logging.level") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for logging.level change, got %v", warnings)
+	}
+}
+
+func TestNonReloadableChanges_TrustedProxiesChange(t *testing.T) {
+	old := &GatewayConfig{
+		Server: ServerConfig{TrustedProxies: []string{"10.0.0.0/8"}},
+	}
+	new := &GatewayConfig{
+		Server: ServerConfig{TrustedProxies: []string{"172.16.0.0/12"}},
+	}
+
+	warnings := NonReloadableChanges(old, new)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "trusted_proxies") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for trusted_proxies change, got %v", warnings)
+	}
+}
+
+func TestNonReloadableChanges_NoChanges(t *testing.T) {
+	cfg := &GatewayConfig{
+		Server:    ServerConfig{Host: "0.0.0.0", Port: 8080},
+		Logging:   LoggingConfig{Level: "info"},
+		RateLimit: RateLimitGlobalConfig{Backend: "memory"},
+	}
+
+	warnings := NonReloadableChanges(cfg, cfg)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for identical config, got %v", warnings)
+	}
+}
+
+func TestDiffSummary_RouteAdded(t *testing.T) {
+	old := &GatewayConfig{}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "new-route", Match: MatchConfig{PathRegex: "^/new"}},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "added") {
+		t.Errorf("expected 'added' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_RouteRemoved(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "old-route", Match: MatchConfig{PathRegex: "^/old"}},
+		},
+	}
+	new := &GatewayConfig{}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "removed") {
+		t.Errorf("expected 'removed' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_RouteModified(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "api", Match: MatchConfig{PathRegex: "^/api"}, Upstream: UpstreamConfig{URL: "http://old:8080"}},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "api", Match: MatchConfig{PathRegex: "^/api"}, Upstream: UpstreamConfig{URL: "http://new:8080"}},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "modified") {
+		t.Errorf("expected 'modified' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_CORSChanged(t *testing.T) {
+	old := &GatewayConfig{
+		CORS: CORSConfig{AllowedOrigins: []string{"https://old.example.com"}},
+	}
+	new := &GatewayConfig{
+		CORS: CORSConfig{AllowedOrigins: []string{"https://new.example.com"}},
+	}
+
+	changes := DiffSummary(old, new)
+	found := false
+	for _, c := range changes {
+		if strings.Contains(c, "CORS") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CORS change in diff, got %v", changes)
+	}
+}
+
+func TestDiffSummary_NoChanges(t *testing.T) {
+	cfg := &GatewayConfig{
+		CORS: CORSConfig{AllowedOrigins: []string{"https://example.com"}},
+		Routes: []RouteConfig{
+			{Name: "api", Match: MatchConfig{PathRegex: "^/api"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+
+	changes := DiffSummary(cfg, cfg)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes for identical config, got %v", changes)
+	}
+}
+
+func TestDiffSummary_RateLimitModified(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{
+				Name:      "api",
+				Match:     MatchConfig{PathRegex: "^/api"},
+				Upstream:  UpstreamConfig{URL: "http://svc:8080"},
+				RateLimit: &RouteLimitConfig{RequestsPerWindow: 100, Window: time.Minute},
+			},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{
+				Name:      "api",
+				Match:     MatchConfig{PathRegex: "^/api"},
+				Upstream:  UpstreamConfig{URL: "http://svc:8080"},
+				RateLimit: &RouteLimitConfig{RequestsPerWindow: 200, Window: time.Minute},
+			},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "modified") {
+		t.Errorf("expected 'modified' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_TransformModified(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{
+				Name:     "api",
+				Match:    MatchConfig{PathRegex: "^/api"},
+				Upstream: UpstreamConfig{URL: "http://svc:8080"},
+				Transform: &TransformConfig{
+					Request: &DirectionTransform{
+						Headers: &HeaderTransform{Add: map[string]string{"X-Old": "true"}},
+					},
+				},
+			},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{
+				Name:     "api",
+				Match:    MatchConfig{PathRegex: "^/api"},
+				Upstream: UpstreamConfig{URL: "http://svc:8080"},
+				Transform: &TransformConfig{
+					Request: &DirectionTransform{
+						Headers: &HeaderTransform{Add: map[string]string{"X-New": "true"}},
+					},
+				},
+			},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "modified") {
+		t.Errorf("expected 'modified' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_TransformAddedToRoute(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "api", Match: MatchConfig{PathRegex: "^/api"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{
+				Name:     "api",
+				Match:    MatchConfig{PathRegex: "^/api"},
+				Upstream: UpstreamConfig{URL: "http://svc:8080"},
+				Transform: &TransformConfig{
+					Request: &DirectionTransform{
+						Headers: &HeaderTransform{Add: map[string]string{"X-Added": "true"}},
+					},
+				},
+			},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if !strings.Contains(changes[0], "modified") {
+		t.Errorf("expected 'modified' in change, got %q", changes[0])
+	}
+}
+
+func TestDiffSummary_RouteOrderChanged(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "api-a", Match: MatchConfig{PathRegex: "^/a"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+			{Name: "api-b", Match: MatchConfig{PathRegex: "^/b"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "api-b", Match: MatchConfig{PathRegex: "^/b"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+			{Name: "api-a", Match: MatchConfig{PathRegex: "^/a"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	found := false
+	for _, c := range changes {
+		if strings.Contains(c, "order") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected route order change in diff, got %v", changes)
+	}
+}
+
+func TestDiffSummary_MultipleChanges(t *testing.T) {
+	old := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "keep", Match: MatchConfig{PathRegex: "^/keep"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+			{Name: "remove-me", Match: MatchConfig{PathRegex: "^/remove"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+	new := &GatewayConfig{
+		Routes: []RouteConfig{
+			{Name: "keep", Match: MatchConfig{PathRegex: "^/keep"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+			{Name: "add-me", Match: MatchConfig{PathRegex: "^/add"}, Upstream: UpstreamConfig{URL: "http://svc:8080"}},
+		},
+	}
+
+	changes := DiffSummary(old, new)
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes (add + remove), got %d: %v", len(changes), changes)
+	}
+
+	foundAdd, foundRemove := false, false
+	for _, c := range changes {
+		if strings.Contains(c, "added") {
+			foundAdd = true
+		}
+		if strings.Contains(c, "removed") {
+			foundRemove = true
+		}
+	}
+	if !foundAdd || !foundRemove {
+		t.Errorf("expected add and remove changes, got %v", changes)
+	}
+}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -806,5 +807,365 @@ func TestIntegration_MethodFiltering(t *testing.T) {
 	rr := doRequest(gw.handler, "POST", "/public/data", nil, "")
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for wrong method, got %d", rr.Code)
+	}
+}
+
+// handlerRef wraps an http.Handler for use with atomic.Pointer (mirrors cmd/gateway).
+type handlerRef struct{ h http.Handler }
+
+// buildTestHandler builds a globalChain(router) handler from routes and shared resources.
+func buildTestHandler(
+	t *testing.T,
+	routes []config.RouteConfig,
+	authenticators map[string]auth.Authenticator,
+	limiter ratelimit.Limiter,
+	metrics *observability.MetricsCollector,
+	corsConfig config.CORSConfig,
+) http.Handler {
+	t.Helper()
+
+	handlers := make(map[string]http.Handler, len(routes))
+	for i := range routes {
+		h := proxy.NewProxyHandler(&routes[i])
+		route := &routes[i]
+
+		if route.CircuitBreaker != nil {
+			cb := circuitbreaker.New(route.CircuitBreaker, route.Name,
+				circuitbreaker.WithOnStateChange(func(routeName string, from, to circuitbreaker.State) {
+					metrics.CircuitBreakerState.WithLabelValues(routeName, to.String()).Set(1)
+					metrics.CircuitBreakerState.WithLabelValues(routeName, from.String()).Set(0)
+				}),
+			)
+			if route.Retry != nil {
+				h = retry.Retry(route.Retry, cb, h, retry.WithSleep(func(time.Duration) {}))
+			} else {
+				h = retry.WithCircuitBreaker(cb, h)
+			}
+		} else if route.Retry != nil {
+			h = retry.Retry(route.Retry, nil, h, retry.WithSleep(func(time.Duration) {}))
+		}
+
+		if route.Transform != nil {
+			h = transform.RequestTransform(route.Transform.Request, route.Transform.MaxBodySize)(
+				transform.ResponseTransform(route.Transform.Response, route.Transform.MaxBodySize)(h))
+		}
+
+		if route.CORS != nil {
+			h = middleware.CORSOverride(*route.CORS)(h)
+		}
+
+		h = auth.Middleware(slog.Default(), authenticators)(h)
+		h = ratelimit.RateLimit(limiter, metrics, nil)(h)
+
+		handlers[route.Name] = h
+	}
+
+	r := router.New(routes, handlers)
+
+	globalChain := middleware.Chain(
+		middleware.Recovery(),
+		middleware.RequestID(),
+		metrics.Middleware(),
+		middleware.CORS(corsConfig),
+	)
+
+	return globalChain(r)
+}
+
+func TestIntegration_ConfigReload(t *testing.T) {
+	mock := &mockUpstream{}
+	upstreamServer := httptest.NewServer(mock)
+	t.Cleanup(upstreamServer.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	authenticators := map[string]auth.Authenticator{}
+	registry := prometheus.NewRegistry()
+	metrics := observability.NewMetricsCollector(registry)
+	limiter := ratelimit.NewMemoryLimiter(ctx)
+
+	corsConfig := config.CORSConfig{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET"},
+		AllowCredentials: false,
+	}
+
+	// Initial routes: only /v1/...
+	initialRoutes := []config.RouteConfig{
+		{
+			Name:  "v1",
+			Match: config.MatchConfig{PathRegex: `^/v1/(?P<rest>.*)$`},
+			Upstream: config.UpstreamConfig{
+				URL:         upstreamServer.URL,
+				PathRewrite: "/api/{rest}",
+				Timeout:     5 * time.Second,
+			},
+		},
+	}
+
+	initialHandler := buildTestHandler(t, initialRoutes, authenticators, limiter, metrics, corsConfig)
+
+	// Set up atomic handler pointer.
+	var current atomic.Pointer[handlerRef]
+	current.Store(&handlerRef{h: initialHandler})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().h.ServeHTTP(w, r)
+	}))
+
+	// Verify initial route works.
+	rr := doRequest(mux, "GET", "/v1/items", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /v1/items, got %d", rr.Code)
+	}
+
+	// Verify /v2/ does not exist yet.
+	rr = doRequest(mux, "GET", "/v2/items", nil, "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for /v2/items before reload, got %d", rr.Code)
+	}
+
+	// Simulate reload: add /v2/ route, remove /v1/ route.
+	newRoutes := []config.RouteConfig{
+		{
+			Name:  "v2",
+			Match: config.MatchConfig{PathRegex: `^/v2/(?P<rest>.*)$`},
+			Upstream: config.UpstreamConfig{
+				URL:         upstreamServer.URL,
+				PathRewrite: "/api/{rest}",
+				Timeout:     5 * time.Second,
+			},
+		},
+	}
+
+	newHandler := buildTestHandler(t, newRoutes, authenticators, limiter, metrics, corsConfig)
+
+	// Atomic swap.
+	current.Store(&handlerRef{h: newHandler})
+
+	// After reload: /v2/ should work.
+	rr = doRequest(mux, "GET", "/v2/items", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /v2/items after reload, got %d", rr.Code)
+	}
+	body := decodeJSON(t, rr)
+	if body["echo_path"] != "/api/items" {
+		t.Errorf("expected echo_path=/api/items, got %v", body["echo_path"])
+	}
+
+	// After reload: /v1/ should return 404.
+	rr = doRequest(mux, "GET", "/v1/items", nil, "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for /v1/items after reload, got %d", rr.Code)
+	}
+}
+
+func TestIntegration_ConfigReload_InvalidConfigKeepsOldHandler(t *testing.T) {
+	mock := &mockUpstream{}
+	upstreamServer := httptest.NewServer(mock)
+	t.Cleanup(upstreamServer.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	authenticators := map[string]auth.Authenticator{}
+	registry := prometheus.NewRegistry()
+	metrics := observability.NewMetricsCollector(registry)
+	limiter := ratelimit.NewMemoryLimiter(ctx)
+
+	corsConfig := config.CORSConfig{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET"},
+		AllowCredentials: false,
+	}
+
+	routes := []config.RouteConfig{
+		{
+			Name:  "api",
+			Match: config.MatchConfig{PathRegex: `^/api/(?P<rest>.*)$`},
+			Upstream: config.UpstreamConfig{
+				URL:         upstreamServer.URL,
+				PathRewrite: "/internal/{rest}",
+				Timeout:     5 * time.Second,
+			},
+		},
+	}
+
+	handler := buildTestHandler(t, routes, authenticators, limiter, metrics, corsConfig)
+
+	var current atomic.Pointer[handlerRef]
+	current.Store(&handlerRef{h: handler})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().h.ServeHTTP(w, r)
+	}))
+
+	// Verify route works.
+	rr := doRequest(mux, "GET", "/api/items", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// Simulate failed reload: invalid config → do NOT swap.
+	// (In the real code, handleReload catches the LoadConfig error and skips the swap.)
+	// Here we simulate by validating a bad config and verifying we don't swap.
+	badCfg := &config.GatewayConfig{
+		Routes: []config.RouteConfig{
+			{
+				Name:  "bad",
+				Match: config.MatchConfig{PathRegex: `^/api/[invalid`},
+				Upstream: config.UpstreamConfig{
+					URL: upstreamServer.URL,
+				},
+			},
+		},
+	}
+	if err := badCfg.Validate(); err == nil {
+		t.Fatal("expected validation error for bad regex")
+	}
+	// Handler was NOT swapped — old route should still work.
+	rr = doRequest(mux, "GET", "/api/items", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 after failed reload, got %d", rr.Code)
+	}
+}
+
+func TestIntegration_ConfigReload_ConcurrentRequests(t *testing.T) {
+	mock := &mockUpstream{}
+	upstreamServer := httptest.NewServer(mock)
+	t.Cleanup(upstreamServer.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	authenticators := map[string]auth.Authenticator{}
+	registry := prometheus.NewRegistry()
+	metrics := observability.NewMetricsCollector(registry)
+	limiter := ratelimit.NewMemoryLimiter(ctx)
+
+	corsConfig := config.CORSConfig{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET"},
+	}
+
+	makeRoutes := func(name, prefix string) []config.RouteConfig {
+		return []config.RouteConfig{{
+			Name:  name,
+			Match: config.MatchConfig{PathRegex: `^/` + prefix + `/(?P<rest>.*)$`},
+			Upstream: config.UpstreamConfig{
+				URL:         upstreamServer.URL,
+				PathRewrite: "/api/{rest}",
+				Timeout:     5 * time.Second,
+			},
+		}}
+	}
+
+	initialHandler := buildTestHandler(t, makeRoutes("v1", "v1"), authenticators, limiter, metrics, corsConfig)
+
+	var current atomic.Pointer[handlerRef]
+	current.Store(&handlerRef{h: initialHandler})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().h.ServeHTTP(w, r)
+	}))
+
+	// Fire concurrent requests while swapping handlers.
+	var wg sync.WaitGroup
+	errors := make(chan error, 100)
+
+	// Readers hitting /v1/ and /v2/ concurrently.
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rr := doRequest(mux, "GET", "/v1/data", nil, "")
+			// Before swap: 200; after swap: 404. Both are acceptable.
+			if rr.Code != http.StatusOK && rr.Code != http.StatusNotFound {
+				errors <- fmt.Errorf("unexpected status %d for /v1/data", rr.Code)
+			}
+		}()
+	}
+
+	// Swap in the middle of concurrent requests.
+	newHandler := buildTestHandler(t, makeRoutes("v2", "v2"), authenticators, limiter, metrics, corsConfig)
+	current.Store(&handlerRef{h: newHandler})
+
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rr := doRequest(mux, "GET", "/v2/data", nil, "")
+			// After swap: should be 200. Before swap would be 404.
+			if rr.Code != http.StatusOK && rr.Code != http.StatusNotFound {
+				errors <- fmt.Errorf("unexpected status %d for /v2/data", rr.Code)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func TestIntegration_ConfigReload_ZeroRoutes(t *testing.T) {
+	mock := &mockUpstream{}
+	upstreamServer := httptest.NewServer(mock)
+	t.Cleanup(upstreamServer.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	authenticators := map[string]auth.Authenticator{}
+	registry := prometheus.NewRegistry()
+	metrics := observability.NewMetricsCollector(registry)
+	limiter := ratelimit.NewMemoryLimiter(ctx)
+
+	corsConfig := config.CORSConfig{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET"},
+	}
+
+	initialRoutes := []config.RouteConfig{
+		{
+			Name:  "api",
+			Match: config.MatchConfig{PathRegex: `^/api/(?P<rest>.*)$`},
+			Upstream: config.UpstreamConfig{
+				URL:         upstreamServer.URL,
+				PathRewrite: "/internal/{rest}",
+				Timeout:     5 * time.Second,
+			},
+		},
+	}
+
+	handler := buildTestHandler(t, initialRoutes, authenticators, limiter, metrics, corsConfig)
+
+	var current atomic.Pointer[handlerRef]
+	current.Store(&handlerRef{h: handler})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().h.ServeHTTP(w, r)
+	}))
+
+	// Route works before reload.
+	rr := doRequest(mux, "GET", "/api/items", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// Reload with zero routes — everything becomes 404.
+	emptyHandler := buildTestHandler(t, []config.RouteConfig{}, authenticators, limiter, metrics, corsConfig)
+	current.Store(&handlerRef{h: emptyHandler})
+
+	rr = doRequest(mux, "GET", "/api/items", nil, "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after reload with zero routes, got %d", rr.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Add zero-downtime configuration reload via `SIGHUP` signal using atomic handler swap (`sync/atomic.Pointer`)
- Extract `buildHandler()` from `main()` with panic recovery for safe rebuild on reload
- Add config diffing (`DiffSummary`) and non-reloadable field detection (`NonReloadableChanges`) with warnings for server, rate limit backend, auth provider, trusted proxy, and logging changes
- Add regex pre-validation in `Validate()` to catch invalid path patterns at config load time
- Add route evaluation order change detection in diff summary

Closes #20

## Reloadable vs Non-Reloadable

| Reloadable | Non-reloadable (warn & ignore) |
|---|---|
| Routes (add/remove/modify) | Server host/port/timeouts |
| Rate limit settings (per-route) | Rate limit backend type |
| CORS configuration (global + per-route) | Redis connection settings |
| Transform rules | Auth provider definitions |
| Circuit breaker thresholds | Logging level |
| Retry settings | Trusted proxies |
| Auth provider assignment to routes | |

## Test plan

- [x] All 26+ existing tests pass with race detection
- [x] 18 new config reload unit tests (`reload_test.go`): regex validation, non-reloadable changes (server, backend, redis, auth, logging, trusted proxies, no-changes), diff summary (add, remove, modify, CORS, transforms, rate limits, route order, multiple changes, no-changes)
- [x] 4 new integration tests: atomic handler swap, invalid config keeps old handler, concurrent request safety during swap, zero-routes reload
- [x] `go vet ./...` clean
- [x] Manual test: start gateway, edit config, `kill -HUP`, verify reload logs and new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)