### PR TITLE
ci: add CI status and coverage badges to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           name: coverage
           path: coverage.out
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/jesus-mata/tanugate/actions/workflows/ci.yml"><img src="https://github.com/jesus-mata/tanugate/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/jesus-mata/tanugate"><img src="https://codecov.io/gh/jesus-mata/tanugate/branch/main/graph/badge.svg" alt="Coverage"></a>
+</p>
+
+<p align="center">
   <a href="#features">Features</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
   <a href="#configuration">Configuration</a> &middot;


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI status badge and Codecov coverage badge to the README
- Integrate `codecov/codecov-action@v5` in the CI workflow to upload coverage reports
- Uses `secrets.CODECOV_TOKEN` for authentication

## Test plan
- [ ] Verify CI badge renders correctly on the README
- [ ] Set up Codecov for the repo and add `CODECOV_TOKEN` secret
- [ ] Verify coverage badge renders after a successful CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)